### PR TITLE
Update Environment.php

### DIFF
--- a/src/Kalnoy/Cruddy/Environment.php
+++ b/src/Kalnoy/Cruddy/Environment.php
@@ -151,6 +151,7 @@ class Environment implements JsonableInterface {
      */
     public function translate($key, $default = null)
     {
+        $key = "cruddy::{$key}";
         $line = $this->translator->trans($key);
 
         return $line === $key ? $default : $line;


### PR DESCRIPTION
Now package's lang files in separate directory.

> Many packages ship with their own language lines. Instead of hacking the package's core files to tweak these lines, you may override them by placing files in the app/lang/packages/{locale}/{package} directory. So, for example, if you need to override the English language lines in messages.php for a package named skyrim/hearthfire, you would place a language file at: app/lang/packages/en/hearthfire/messages.php. In this file you would define only the language lines you wish to override. Any language lines you don't override will still be loaded from the package's language files.

http://laravel.com/docs/localization#overriding-package-language-files

For example, we can use `app/lang/packages/ru/cruddy/entities.php` It's more clear.
