### PR TITLE
make password changes automatically hashed

### DIFF
--- a/src/Kalnoy/Cruddy/Schema/Fields/Types/Password.php
+++ b/src/Kalnoy/Cruddy/Schema/Fields/Types/Password.php
@@ -4,6 +4,7 @@ namespace Kalnoy\Cruddy\Schema\Fields\Types;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Kalnoy\Cruddy\Schema\Fields\BaseTextField;
+use Hash;
 
 /**
  * Password field type.
@@ -32,7 +33,15 @@ class Password extends BaseTextField {
     {
         return '';
     }
-
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function process($value)
+    {
+        return Hash::make($value);
+    }
+    
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
sure, there are different ways of user authentication. so this might need an extra process function in the model entity.
but saving passwords as plain text is covering less the use cases of `Hash::make()` ones.
