### PR TITLE
Show unminified JS when in debug mode

### DIFF
--- a/src/CruddyServiceProvider.php
+++ b/src/CruddyServiceProvider.php
@@ -213,7 +213,7 @@ class CruddyServiceProvider extends ServiceProvider
      */
     protected function getJsFiles($baseDir)
     {
-        $ext = config('app.debug') ? '.min.js' : '.js';
+        $ext = config('app.debug') ? '.js' : '.min.js';
 
         return $this->assets($baseDir.'/js', [ 'vendor'.$ext, 'app'.$ext ]);
     }


### PR DESCRIPTION
Updating getJsFiles so set JS extensions to .min.js if the app isn't in debug mode