### PR TITLE
Fix for bug introduced in previous PR for fully qualified column names in queries.

### DIFF
--- a/src/Schema/Entry.php
+++ b/src/Schema/Entry.php
@@ -141,6 +141,14 @@ abstract class Entry implements \Kalnoy\Cruddy\Contracts\Entry {
     }
 
     /**
+     * @return string
+     */
+	public function getFullyQualifiedIdForQuery()
+	{
+		return $this->entity->newModel()->getTable().'.'.$this->id;
+	}
+
+    /**
      * Get an owning entity.
      *
      * @return BaseForm

--- a/src/Schema/Fields/BaseTextField.php
+++ b/src/Schema/Fields/BaseTextField.php
@@ -53,7 +53,7 @@ abstract class BaseTextField extends BaseInput implements KeywordsFilter {
      */
     public function order(Builder $builder, $direction)
     {
-        $builder->orderBy($this->getFullyQualifiedId(), $direction);
+        $builder->orderBy($this->getFullyQualifiedIdForQuery(), $direction);
 
         return $this;
     }
@@ -68,7 +68,7 @@ abstract class BaseTextField extends BaseInput implements KeywordsFilter {
     {
         foreach ($keywords as $keyword)
         {
-            $builder->orWhere($this->getFullyQualifiedId(), 'like', '%'.$keyword.'%');
+            $builder->orWhere($this->getFullyQualifiedIdForQuery(), 'like', '%'.$keyword.'%');
         }
     }
 


### PR DESCRIPTION
Didn't realise that entity->getId() wasnt mapping through to table name.
This commit creates a new method on Entry that does use the table name and I have updates baseTextField to use the method.